### PR TITLE
Clarify vegan options for ceremony and reception variants

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -134,6 +134,30 @@
             </div>
         </section>
 
+        <!-- Food & Drink Information -->
+        <section class="food-notes">
+            <div class="details-card variant-content" data-show="ceremony-western">
+                <h3>Food &amp; Drink</h3>
+                <p>Neither the ceremony nor the reception will be fully vegan, but both will have vegan options
+                    alongside non-vegan dishes.</p>
+                <p>After the ceremony we&rsquo;ll raise a glass of champagne and share vegan and non-vegan canap&eacute;s only until
+                    the venue closes at 1:30pm.</p>
+                <p>That evening the reception dinner will feature Ethiopian curries and injera. There will still be
+                    vegan choices, though the spread will lean more toward non-vegan plates, so please let us know any
+                    specific requirements.</p>
+                <p>If you&rsquo;re with us for the full day, we encourage you to enjoy a good lunch between the ceremony and
+                    reception so you&rsquo;re ready for the evening feast.</p>
+            </div>
+            <div class="details-card variant-content" data-show="reception-western">
+                <h3>Food &amp; Drink</h3>
+                <p>Our celebrations aren&rsquo;t fully vegan, but the reception will still include vegan options alongside
+                    non-vegan dishes.</p>
+                <p>We&rsquo;re serving Ethiopian curries and injera for dinner. The spread will lean more toward non-vegan
+                    plates in the evening, so let us know if you have any specific requirements and we&rsquo;ll make sure
+                    you&rsquo;re looked after.</p>
+            </div>
+        </section>
+
         <!-- Accommodation Information - only for western variants -->
         <section class="accommodation-info variant-content" data-show="ceremony-western,reception-western">
             <div class="details-card">


### PR DESCRIPTION
## Summary
- create variant-specific Food & Drink sections that clarify neither event is fully vegan while noting the available vegan options
- describe the ceremony's champagne and canapés alongside the Ethiopian reception menu, including the evening's non-vegan emphasis
- keep the lunch reminder for full-day guests on the ceremony invitation variant only

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ede3c443c8325926930fe88fbf169)